### PR TITLE
⬆️ 1.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "greenbot-discord",
-	"version": "1.22.0",
+	"version": "1.22.1",
 	"description": "A Discord bot with music, games, and utilities",
 	"exports": "./src/index.ts",
 	"type": "module",

--- a/src/commands/money/allowance.ts
+++ b/src/commands/money/allowance.ts
@@ -42,7 +42,7 @@ export default {
     const embed = new EmbedBuilder()
       .setColor('Random')
       .setTitle('🏦 용돈')
-      .setDescription(`200,000₩을 받았습니다.\n현재 잔액: ${updated.money.toLocaleString()}₩`);
+      .setDescription(`200,000₩을 받았습니다.\n현재 잔액: ${(updated?.money ?? 0n).toLocaleString()}₩`);
     await interaction.editReply({ embeds: [embed] });
   }
 };

--- a/src/commands/money/ladder.ts
+++ b/src/commands/money/ladder.ts
@@ -75,7 +75,8 @@ export default {
         winMoney: isWin ? betting : 0n,
         loseMoney: isWin ? 0n : betting
       })
-      .onDuplicateKeyUpdate({
+      .onConflictDoUpdate({
+        target: activities.id,
         set: {
           money: newBalance,
           winMoney: sql`${activities.winMoney} + ${isWin ? betting : 0n}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-import path from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ShardingManager } from 'discord.js';
 import { logger } from './handler/logger.js';
 
-const botFile = path.join(import.meta.dir, 'bot.ts');
+const botFile = join(dirname(fileURLToPath(import.meta.url)), 'bot.ts');
 
 const manager = new ShardingManager(botFile, {
   token: process.env.TOKEN

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
 		"module": "esnext" /* Specify what module code is generated. */,
 		"rootDir": "./src" /* Specify the root folder within your source files. */,
 		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+		"ignoreDeprecations": "6.0" /* Silence TS 6.0 deprecation errors for moduleResolution=node10 and baseUrl. TODO: migrate to bundler/nodenext. */,
 		"baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
 		"paths": {
 			"@/*": ["src/*"]


### PR DESCRIPTION
## Summary

1.22.0 deploy가 CI 타입체크에서 막혀서 hotfix.

- tsconfig: `ignoreDeprecations: "6.0"` 추가 — TS 6.0이 `moduleResolution=node10` / `baseUrl` deprecation을 error severity로 잡아 CI 실패. 정식 마이그레이션은 별도 진행.
- ladder.ts: `onDuplicateKeyUpdate` (MySQL) → `onConflictDoUpdate` (Postgres). 마이그레이션 잔재.
- allowance.ts: `updated.money` null-safe 처리
- index.ts: `import.meta.dir` (bun 전용) → `fileURLToPath(import.meta.url)` (표준 ESM, bot.ts와 일관)

## Test plan
- [x] `bunx tsc --noEmit` exit 0
- [ ] CI green
- [ ] prod 배포 자동 트리거 후 봇 정상 부팅