### PR TITLE
🔧 .env.example 추가 + env.d.ts 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# ===== Runtime =====
+# production: 글로벌 슬래시 명령어 등록. 프로덕션 (Oracle).
+# development: GUILD_ID 길드에만 명령어 등록. 로컬 개발.
+NODE_ENV=development
+
+# ===== Discord =====
+# 봇 토큰. dev/prod에서 다른 봇 앱(다른 토큰) 사용 권장.
+TOKEN=
+# TOKEN의 application id (Discord Developer Portal).
+CLIENT_ID=
+# 본인의 봇 (BOT_ID와 CLIENT_ID는 보통 동일하지만, userinfo에서 별도 체크용).
+BOT_ID=
+# dev에서만 사용. 슬래시 명령어 즉시 반영을 위한 테스트 길드 id.
+GUILD_ID=
+
+# ===== Database =====
+# Postgres. dev=로컬, prod=Oracle 컨테이너 (127.0.0.1:5434).
+DATABASE_URL=postgres://greenbot:CHANGE_ME@127.0.0.1:5432/greenbot_database
+
+# ===== Lavalink =====
+# dev=로컬에 띄운 Lavalink, prod=Oracle 호스트 IP.
+SERVER_IP=
+LAVALINK_PASSWORD=
+
+# ===== External APIs =====
+# https://thecatapi.com — /cat 명령어
+THE_CAT_API_KEY=
+# https://thedogapi.com — /dog 명령어
+THE_DOG_API_KEY=
+# https://open.neis.go.kr — /급식, /시간표, /학교정보
+NEIS_OPENINFO_KEY=

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,17 +1,15 @@
 declare namespace NodeJS {
   export interface ProcessEnv {
+    NODE_ENV: 'production' | 'development';
     TOKEN: string;
-    BETA_TOKEN: string;
-    THE_CAT_API_KEY: string;
-    THE_DOG_API_KEY: string;
-    ADMIN_ID: string;
     CLIENT_ID: string;
+    BOT_ID: string;
     GUILD_ID: string;
+    DATABASE_URL: string;
     SERVER_IP: string;
     LAVALINK_PASSWORD: string;
-    LAVALINK_PORT: number;
-    DATABASE_URL: string;
+    THE_CAT_API_KEY: string;
+    THE_DOG_API_KEY: string;
     NEIS_OPENINFO_KEY: string;
-    PUTER_TOKEN: string;
   }
 }


### PR DESCRIPTION
## Summary

- `.env.example` 추가: 실제로 사용 중인 11개 환경변수만 환경별 의미와 함께 문서화 (새 머신 셋업 시 `cp .env.example .env` → 채우면 끝)
- `src/types/env.d.ts` 정리: 데드 키 제거 (`BETA_TOKEN`, `ADMIN_ID`, `PUTER_TOKEN`, `LAVALINK_PORT`), 누락된 `NODE_ENV` (`'production' | 'development'` 리터럴), `BOT_ID` 추가
- README에 dev vs prod `.env` 차이 표 (필요 시 별도 PR)

## Test plan
- [x] `bunx tsc --noEmit` 통과
- [ ] 기존 `.env`로 prod 봇 정상 부팅 (변경된 type 정의가 컴파일에 영향 없음)