### PR TITLE
♻️ guildCreate를 Components V2로 마이그레이션

### DIFF
--- a/src/events/client/guildCreate.ts
+++ b/src/events/client/guildCreate.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, Events, type Guild } from 'discord.js';
+import { ContainerBuilder, Events, type Guild, MessageFlags, SeparatorSpacingSize } from 'discord.js';
 import { logger } from '@/handler/logger.js';
 
 export default {
@@ -7,27 +7,28 @@ export default {
   async execute(guild: Guild) {
     logger.info(`Invited to ${guild.name}(${guild.id}), ${guild.memberCount} members`);
 
-    const promises = [
-      guild.client.shard?.fetchClientValues('guilds.cache.size'),
-      guild.client.shard?.broadcastEval((c) => c.guilds.cache.reduce((acc, guild) => acc + guild.memberCount, 0))
-    ];
+    const [guildSizes, memberSizes] = await Promise.all([
+      guild.client.shard?.fetchClientValues('guilds.cache.size') as Promise<number[]>,
+      guild.client.shard?.broadcastEval((c) => c.guilds.cache.reduce((acc, g) => acc + g.memberCount, 0)) as Promise<number[]>
+    ]);
+    const totalGuilds = guildSizes.reduce((a, b) => a + b, 0).toLocaleString();
+    const totalMembers = memberSizes.reduce((a, b) => a + b, 0).toLocaleString();
 
-    await Promise.all(promises).then(async (results: any) => {
-      const totalGuilds = results[0].reduce((acc: any, guildCount: any) => acc + guildCount, 0).toLocaleString();
-      const totalMembers = results[1].reduce((acc: any, memberCount: any) => acc + memberCount, 0).toLocaleString();
+    const container = new ContainerBuilder()
+      .setAccentColor(0x73c55c)
+      .addTextDisplayComponents(
+        (text) => text.setContent('## 🙇‍♂️ 초대해 주셔서 감사합니다!'),
+        (text) => text.setContent(`그린Bot은 **${totalGuilds}개의 서버, ${totalMembers}명의 유저**와 함께 하고 있습니다!`)
+      )
+      .addSeparatorComponents((sep) => sep.setSpacing(SeparatorSpacingSize.Small))
+      .addTextDisplayComponents((text) =>
+        text.setContent('💌 [한국 디스코드 리스트](https://bit.ly/3TveLdR)\n🆘 [디스코드 지원 서버](https://discord.gg/7znkdKNxm8)\n🐱 [깃허브](https://bit.ly/3z8JMfg)')
+      )
+      .addSeparatorComponents((sep) => sep.setSpacing(SeparatorSpacingSize.Small).setDivider(false))
+      .addTextDisplayComponents((text) =>
+        text.setContent('-# /언어 명령어로 언어를 변경할 수 있습니다.\n-# You can change the language with the /language command.')
+      );
 
-      const embed = new EmbedBuilder()
-        .setColor('#73C55C')
-        .setTitle('초대해 주셔서 감사합니다! 🙇‍♂️')
-        .setDescription(`그린Bot은 **${totalGuilds}개의 서버, ${totalMembers}명의 유저**와 함께 하고 있습니다!`)
-        .addFields(
-          { name: '💌 링크', value: '[한국 디스코드 리스트](https://bit.ly/3TveLdR)', inline: true },
-          { name: '🆘 지원 서버', value: '[디스코드 지원 서버](https://discord.gg/7znkdKNxm8)', inline: true },
-          { name: '🐱 깃허브', value: '[깃허브 링크](https://bit.ly/3z8JMfg)', inline: true }
-        )
-        .setFooter({ text: '/언어 명령어로 언어를 변경할 수 있습니다.\nYou can change the language with the /language command.' });
-
-      await guild.systemChannel?.send({ embeds: [embed] });
-    });
+    await guild.systemChannel?.send({ components: [container], flags: MessageFlags.IsComponentsV2 });
   }
 };


### PR DESCRIPTION
## Summary

봇이 새 서버에 초대됐을 때 보내는 환영 메시지를 `EmbedBuilder` → `ContainerBuilder` (Components V2)로 전환.

- 3개의 inline field → 한 텍스트 블록 (이모지 + 링크 한 줄씩)
- footer → `-#` 마크다운 (Discord의 subtle/small 텍스트)
- separator로 영역 구분
- `Promise.all().then()` 안티패턴 → 직접 destructuring
- 색상 `'#73C55C'` → `0x73c55c`

다른 곳에서 쓰는 ContainerBuilder 스타일과 일관됩니다.

## Test plan
- [x] `bunx tsc --noEmit` 통과
- [ ] 새 서버 초대 시 환영 메시지 정상 출력 확인