### PR TITLE
🗃️ users.language NOT NULL 제약 + 기본값 'ko'

### DIFF
--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -6,7 +6,7 @@ export const users = pgTable('users', {
   banned: boolean(),
   bannedReason: varchar({ length: 255 }),
   count: bigint({ mode: 'bigint' }).default(sql`0`),
-  language: varchar({ length: 10 }).default('ko'),
+  language: varchar({ length: 10 }).notNull().default('ko'),
   createdAt: timestamp().defaultNow(),
   updatedAt: timestamp()
     .defaultNow()


### PR DESCRIPTION
## Summary

`users.language` 컬럼을 `varchar(10)` (nullable, default 'ko') → **NOT NULL + default 'ko'**로 변경.

### 배경
Prisma → Drizzle 마이그레이션 시 MySQL의 `varchar(191) NOT NULL` 컬럼에서 빈 문자열로 들어와있던 사용자가 7,991명 존재 (전체의 ~40%). `?? 'ko'` 연산자는 빈 문자열을 통과시켜서 `locale = ''`가 되는 상황. 다행히 i18next `fallbackLng: 'ko'` 덕에 사용자 영향은 없었지만 데이터/타입 불일치.

### 변경 내용
- 기존 빈 문자열 7,991행을 'ko'로 backfill (prod에 직접 적용 완료)
- 스키마에 `.notNull()` 추가 → 신규 사용자도 무조건 'ko' (default) 또는 명시값
- prod DB도 `drizzle-kit push`로 동기화 완료

### 안전성
신규 user 행은 interactionCreate에서 `id`만 명시 → DB default 'ko'로 채워짐. 기존 사용자는 `/language` 명령으로 변경 가능.

## Test plan
- [x] `bunx tsc --noEmit` 통과
- [x] prod DB 적용 완료 (`is_nullable: NO`, default `'ko'::character varying`)
- [x] 빈 문자열 0건 확인