### PR TITLE
🌐 명령어 i18n 다국어 적용

### DIFF
--- a/src/commands/info/hangang.ts
+++ b/src/commands/info/hangang.ts
@@ -56,21 +56,24 @@ export default {
     const hottestStation = validStations.reduce((previous, current) => (current.TEMP > previous.TEMP ? current : previous));
     const coldestStation = validStations.reduce((previous, current) => (current.TEMP < previous.TEMP ? current : previous));
 
+    const t = interaction.i18n;
+    const na = t('command.hangang.notMeasurable');
+
     const container = new ContainerBuilder();
     container.addTextDisplayComponents(
-      (text) => text.setContent('## 🌊 한강 수온'),
-      (text) => text.setContent(`마지막 업데이트: ${time(data.DATAs.CACHE_META.UPDATED_AT, TimestampStyles.LongDateShortTime)}`)
+      (text) => text.setContent(`## ${t('command.hangang.title')}`),
+      (text) => text.setContent(`${t('command.hangang.lastUpdate')}: ${time(data.DATAs.CACHE_META.UPDATED_AT, TimestampStyles.LongDateShortTime)}`)
     );
     container.addSeparatorComponents((separator) => separator.setSpacing(SeparatorSpacingSize.Small).setDivider(true));
     if (validStations.length > 0) {
       container.addTextDisplayComponents(
-        (text) => text.setContent('### 📊 한눈에 보기'),
+        (text) => text.setContent(`### ${t('command.hangang.overview')}`),
         (text) =>
           text.setContent(
-            `- **평균 수온:** ${averageTemperature.toFixed(1)}°C\n` +
-              `- **가장 따뜻한 곳:** ${hottestStation.location} (${hottestStation.TEMP.toFixed(1)}°C)\n` +
-              `- **가장 차가운 곳:** ${coldestStation.location} (${coldestStation.TEMP.toFixed(1)}°C)\n` +
-              `- **측정 지점:** ${stations.length}곳`
+            `- **${t('command.hangang.avgTemp')}:** ${averageTemperature.toFixed(1)}°C\n` +
+              `- **${t('command.hangang.hottest')}:** ${hottestStation.location} (${hottestStation.TEMP.toFixed(1)}°C)\n` +
+              `- **${t('command.hangang.coldest')}:** ${coldestStation.location} (${coldestStation.TEMP.toFixed(1)}°C)\n` +
+              `- **${t('command.hangang.stations')}:** ${t('command.hangang.stationsCount', { count: stations.length })}`
           )
       );
     }
@@ -79,9 +82,9 @@ export default {
       container.addTextDisplayComponents((text) =>
         text.setContent(
           `### ${station.location}\n` +
-            `🌡️ **수온:** ${station.TEMP != null ? `${station.TEMP.toFixed(1)}°C` : '측정 불가'}\n` +
-            `🧪 **PH:** ${station.PH != null ? station.PH.toFixed(1) : '측정 불가'}\n` +
-            `🕒 **기준 시각:** ${time(dayjs(station.LAST_UPDATE).unix(), TimestampStyles.LongDateShortTime)}`
+            `🌡️ **${t('command.hangang.temperature')}:** ${station.TEMP != null ? `${station.TEMP.toFixed(1)}°C` : na}\n` +
+            `🧪 **${t('command.hangang.ph')}:** ${station.PH != null ? station.PH.toFixed(1) : na}\n` +
+            `🕒 **${t('command.hangang.timestamp')}:** ${time(dayjs(station.LAST_UPDATE).unix(), TimestampStyles.LongDateShortTime)}`
         )
       );
       if (index < stations.length - 1) {

--- a/src/commands/info/serverinfo.ts
+++ b/src/commands/info/serverinfo.ts
@@ -1,18 +1,18 @@
 import { type ChatInputCommandInteraction, EmbedBuilder, GuildPremiumTier, GuildVerificationLevel, SlashCommandBuilder, time } from 'discord.js';
 
-const verificationLevels: Record<GuildVerificationLevel, string> = {
-  [GuildVerificationLevel.None]: '🟢 없음',
-  [GuildVerificationLevel.Low]: '🟡 낮음 (이메일 인증)',
-  [GuildVerificationLevel.Medium]: '🟠 중간 (가입 5분 대기)',
-  [GuildVerificationLevel.High]: '🔴 높음 (가입 10분 대기)',
-  [GuildVerificationLevel.VeryHigh]: '🟣 매우 높음 (핸드폰 인증)'
+const verificationKeys: Record<GuildVerificationLevel, string> = {
+  [GuildVerificationLevel.None]: 'command.serverinfo.verification.none',
+  [GuildVerificationLevel.Low]: 'command.serverinfo.verification.low',
+  [GuildVerificationLevel.Medium]: 'command.serverinfo.verification.medium',
+  [GuildVerificationLevel.High]: 'command.serverinfo.verification.high',
+  [GuildVerificationLevel.VeryHigh]: 'command.serverinfo.verification.veryHigh'
 };
 
-const boostTiers: Record<GuildPremiumTier, string> = {
-  [GuildPremiumTier.None]: '0레벨',
-  [GuildPremiumTier.Tier1]: '1레벨',
-  [GuildPremiumTier.Tier2]: '2레벨',
-  [GuildPremiumTier.Tier3]: '3레벨'
+const boostTierLabels: Record<GuildPremiumTier, string> = {
+  [GuildPremiumTier.None]: '0',
+  [GuildPremiumTier.Tier1]: '1',
+  [GuildPremiumTier.Tier2]: '2',
+  [GuildPremiumTier.Tier3]: '3'
 };
 
 export default {
@@ -24,30 +24,32 @@ export default {
 
   async execute(interaction: ChatInputCommandInteraction<'cached'>) {
     const { guild } = interaction;
+    const t = interaction.i18n;
+    const none = t('command.serverinfo.none');
 
     const embed = new EmbedBuilder()
       .setColor('Random')
       .setThumbnail(guild.iconURL({ size: 4096 }))
-      .setTitle(`'${guild.name}' 정보`)
+      .setTitle(t('command.serverinfo.title', { name: guild.name }))
       .setImage(guild.bannerURL({ size: 4096 }))
       .addFields(
-        { name: '📛 이름', value: guild.name, inline: true },
-        { name: '📝 서버 설명', value: guild.description ?? '없음', inline: true },
-        { name: '🆔 서버 ID', value: guild.id, inline: true },
-        { name: '👑 서버 소유자', value: `<@${guild.ownerId}>`, inline: true },
-        { name: '🎂 서버 생성일', value: time(guild.createdAt), inline: true },
-        { name: '👤 유저 수', value: `${guild.memberCount}명`, inline: true },
-        { name: '🎭 역할 수', value: `${guild.roles.cache.size}개`, inline: true },
-        { name: '📺 채널 수', value: `${guild.channels.cache.size}개`, inline: true },
-        { name: '🕮 규칙 채널', value: guild.rulesChannelId ? `<#${guild.rulesChannelId}>` : '없음', inline: true },
-        { name: '🌐 서버 지역', value: guild.preferredLocale, inline: true },
-        { name: '🔒 보안 수준', value: verificationLevels[guild.verificationLevel], inline: true },
-        { name: '📢 업데이트 채널', value: guild.publicUpdatesChannel ? `<#${guild.publicUpdatesChannelId}>` : '없음', inline: true },
-        { name: '⚙️ 시스템 채널', value: guild.systemChannel ? `<#${guild.systemChannelId}>` : '없음', inline: true },
-        { name: '💤 AFK 채널', value: guild.afkChannel ? `<#${guild.afkChannelId}>` : '없음', inline: true },
-        { name: '⏰ AFK 시간', value: `${guild.afkTimeout / 60}분`, inline: true },
-        { name: '✨ 부스트 레벨', value: boostTiers[guild.premiumTier], inline: true },
-        { name: '🌟 부스트 수', value: `${guild.premiumSubscriptionCount ?? 0}개`, inline: true }
+        { name: t('command.serverinfo.name'), value: guild.name, inline: true },
+        { name: t('command.serverinfo.description'), value: guild.description ?? none, inline: true },
+        { name: t('command.serverinfo.id'), value: guild.id, inline: true },
+        { name: t('command.serverinfo.owner'), value: `<@${guild.ownerId}>`, inline: true },
+        { name: t('command.serverinfo.createdAt'), value: time(guild.createdAt), inline: true },
+        { name: t('command.serverinfo.memberCount'), value: t('command.serverinfo.memberCountValue', { count: guild.memberCount }), inline: true },
+        { name: t('command.serverinfo.roleCount'), value: t('command.serverinfo.countSuffix', { count: guild.roles.cache.size }), inline: true },
+        { name: t('command.serverinfo.channelCount'), value: t('command.serverinfo.countSuffix', { count: guild.channels.cache.size }), inline: true },
+        { name: t('command.serverinfo.rulesChannel'), value: guild.rulesChannelId ? `<#${guild.rulesChannelId}>` : none, inline: true },
+        { name: t('command.serverinfo.locale'), value: guild.preferredLocale, inline: true },
+        { name: t('command.serverinfo.verification.label'), value: t(verificationKeys[guild.verificationLevel]), inline: true },
+        { name: t('command.serverinfo.updatesChannel'), value: guild.publicUpdatesChannel ? `<#${guild.publicUpdatesChannelId}>` : none, inline: true },
+        { name: t('command.serverinfo.systemChannel'), value: guild.systemChannel ? `<#${guild.systemChannelId}>` : none, inline: true },
+        { name: t('command.serverinfo.afkChannel'), value: guild.afkChannel ? `<#${guild.afkChannelId}>` : none, inline: true },
+        { name: t('command.serverinfo.afkTimeout'), value: t('command.serverinfo.minutes', { count: guild.afkTimeout / 60 }), inline: true },
+        { name: t('command.serverinfo.boostLevel'), value: boostTierLabels[guild.premiumTier], inline: true },
+        { name: t('command.serverinfo.boostCount'), value: t('command.serverinfo.countSuffix', { count: guild.premiumSubscriptionCount ?? 0 }), inline: true }
       );
     await interaction.reply({ embeds: [embed] });
   }

--- a/src/commands/info/urban.ts
+++ b/src/commands/info/urban.ts
@@ -34,8 +34,13 @@ export default {
     const data = response.list?.[0];
     if (!data) return interaction.error.invalidArgument();
 
-    const definition = data.definition ? (data.definition.length > 1024 ? `${data.definition.slice(0, 1021)}...` : data.definition) : '정의 없음';
-    const example = data.example ? (data.example.length > 1024 ? `${data.example.slice(0, 1021)}...` : data.example) : '예문 없음';
+    const t = interaction.i18n;
+    const definition = data.definition
+      ? data.definition.length > 1024
+        ? `${data.definition.slice(0, 1021)}...`
+        : data.definition
+      : t('command.urban.noDefinition');
+    const example = data.example ? (data.example.length > 1024 ? `${data.example.slice(0, 1021)}...` : data.example) : t('command.urban.noExample');
 
     const container = new ContainerBuilder()
       .addTextDisplayComponents(
@@ -43,10 +48,12 @@ export default {
         (textDisplay) => textDisplay.setContent(definition)
       )
       .addTextDisplayComponents(
-        (textDisplay) => textDisplay.setContent(`## 예문`),
+        (textDisplay) => textDisplay.setContent(t('command.urban.example')),
         (textDisplay) => textDisplay.setContent(example)
       )
-      .addTextDisplayComponents((textDisplay) => textDisplay.setContent(`-# 작성자: ${data.author} · 작성일: ${time(new Date(data.written_on))}`));
+      .addTextDisplayComponents((textDisplay) =>
+        textDisplay.setContent(`-# ${t('command.urban.author')}: ${data.author} · ${t('command.urban.writtenOn')}: ${time(new Date(data.written_on))}`)
+      );
     await interaction.editReply({ components: [container], flags: MessageFlags.IsComponentsV2 });
   }
 };

--- a/src/commands/info/userinfo.ts
+++ b/src/commands/info/userinfo.ts
@@ -15,20 +15,20 @@ import {
   version
 } from 'discord.js';
 
-const badgeEmojis: Record<string, string> = {
-  Staff: '👨‍💼 Discord 직원',
-  Partner: '🤝 파트너',
-  Hypesquad: '🏠 HypeSquad 이벤트',
-  HypeSquadOnlineHouse1: '🟣 HypeSquad Bravery',
-  HypeSquadOnlineHouse2: '🟠 HypeSquad Brilliance',
-  HypeSquadOnlineHouse3: '🟢 HypeSquad Balance',
-  BugHunterLevel1: '🐛 버그 헌터 Lv.1',
-  BugHunterLevel2: '🐛 버그 헌터 Lv.2',
-  PremiumEarlySupporter: '💎 초기 Nitro 서포터',
-  VerifiedDeveloper: '✅ 초기 인증된 봇 개발자',
-  CertifiedModerator: '🛡️ 모더레이터 프로그램 동문',
-  ActiveDeveloper: '🔨 활동 중인 개발자'
-};
+const knownFlags = new Set([
+  'Staff',
+  'Partner',
+  'Hypesquad',
+  'HypeSquadOnlineHouse1',
+  'HypeSquadOnlineHouse2',
+  'HypeSquadOnlineHouse3',
+  'BugHunterLevel1',
+  'BugHunterLevel2',
+  'PremiumEarlySupporter',
+  'VerifiedDeveloper',
+  'CertifiedModerator',
+  'ActiveDeveloper'
+]);
 
 export default {
   data: new SlashCommandBuilder()
@@ -58,6 +58,7 @@ export default {
     const member = interaction.options.getMember('user');
     if (member == null) return;
 
+    const t = interaction.i18n;
     const user = await member.user.fetch();
     const avatarURL = user.displayAvatarURL({ extension: 'png', size: 4096 });
     const roles = member.roles.cache.filter((role) => role.id !== interaction.guildId).sort((a, b) => b.position - a.position);
@@ -69,16 +70,18 @@ export default {
     const joinedAt =
       member.joinedTimestamp != null
         ? `${time(new Date(member.joinedTimestamp), TimestampStyles.LongDate)} (${time(new Date(member.joinedTimestamp), TimestampStyles.RelativeTime)})`
-        : '알 수 없음';
+        : t('command.userinfo.unknown');
 
     const lines = [
-      `📛 **이름:** ${user.username}${nickname}${user.bot ? ' 🤖' : ''}`,
-      `🆔 **ID:** ${user.id}`,
-      `🎂 **계정 생성일:** ${time(user.createdAt, TimestampStyles.LongDate)} (${time(user.createdAt, TimestampStyles.RelativeTime)})`,
-      `📅 **서버 가입일:** ${joinedAt}`
-    ];
+      `${t('command.userinfo.name')}:** ${user.username}${nickname}${user.bot ? ' 🤖' : ''}`,
+      `${t('command.userinfo.id')}:** ${user.id}`,
+      `${t('command.userinfo.createdAt')}:** ${time(user.createdAt, TimestampStyles.LongDate)} (${time(user.createdAt, TimestampStyles.RelativeTime)})`,
+      `${t('command.userinfo.joinedAt')}:** ${joinedAt}`
+    ].map((s) => `**${s}`);
     if (member.premiumSince) {
-      lines.push(`🚀 **부스트 시작일:** ${time(member.premiumSince, TimestampStyles.LongDate)} (${time(member.premiumSince, TimestampStyles.RelativeTime)})`);
+      lines.push(
+        `**${t('command.userinfo.premiumSince')}:** ${time(member.premiumSince, TimestampStyles.LongDate)} (${time(member.premiumSince, TimestampStyles.RelativeTime)})`
+      );
     }
     const info = lines.join('\n');
 
@@ -90,16 +93,18 @@ export default {
 
     // 배지
     const flags = user.flags?.toArray() ?? [];
-    const badges = flags.map((flag) => badgeEmojis[flag]).filter(Boolean);
+    const badges = flags.filter((f) => knownFlags.has(f)).map((f) => t(`command.userinfo.flags.${f}`));
     if (badges.length > 0) {
       container.addSeparatorComponents((separator) => separator.setSpacing(SeparatorSpacingSize.Small).setDivider(true));
-      container.addTextDisplayComponents((text) => text.setContent(`🏅 **배지:** ${badges.join(', ')}`));
+      container.addTextDisplayComponents((text) => text.setContent(`**${t('command.userinfo.badges')}:** ${badges.join(', ')}`));
     }
 
     // 역할
     if (roles.size > 0) {
       container.addSeparatorComponents((separator) => separator.setSpacing(SeparatorSpacingSize.Small).setDivider(true));
-      container.addTextDisplayComponents((text) => text.setContent(`🏷️ **역할 (${roles.size}):** ${roles.map((role) => role.toString()).join(' ')}`));
+      container.addTextDisplayComponents((text) =>
+        text.setContent(`**${t('command.userinfo.roles', { count: roles.size })}:** ${roles.map((role) => role.toString()).join(' ')}`)
+      );
     }
 
     // 배너
@@ -114,9 +119,9 @@ export default {
       container.addSeparatorComponents((separator) => separator.setSpacing(SeparatorSpacingSize.Small).setDivider(true));
       container.addTextDisplayComponents((text) =>
         text.setContent(
-          `### 🤖 봇 정보\n` +
-            `🖥️ **OS:** ${os.platform()} ${os.arch()} ${os.release()}\n` +
-            `💾 **메모리:** ${(os.freemem() / 1024 ** 3).toFixed(2)}GB / ${(os.totalmem() / 1024 ** 3).toFixed(2)}GB\n` +
+          `### ${t('command.userinfo.botInfo')}\n` +
+            `**${t('command.userinfo.botOs')}:** ${os.platform()} ${os.arch()} ${os.release()}\n` +
+            `**${t('command.userinfo.botMemory')}:** ${(os.freemem() / 1024 ** 3).toFixed(2)}GB / ${(os.totalmem() / 1024 ** 3).toFixed(2)}GB\n` +
             `💻 **CPU:** ${os.cpus()[0].model}\n` +
             `📂 **Node.js:** ${process.version}\n` +
             `📦 **discord.js:** ${version}`

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -21,11 +21,12 @@ export default {
     const { tracks } = player.queue;
     const { info } = currentTrack;
 
+    const i18n = interaction.i18n;
     const embed = new EmbedBuilder()
       .setColor('Random')
       .setTitle(info.title)
       .setURL(info.uri)
-      .addFields({ name: '🎤 아티스트', value: info.author, inline: true }, { name: '📀 소스', value: info.sourceName, inline: true })
+      .addFields({ name: i18n('command.queue.author'), value: info.author, inline: true }, { name: i18n('command.queue.source'), value: info.sourceName, inline: true })
       .setTimestamp();
     if (info.artworkUrl) embed.setThumbnail(info.artworkUrl);
 
@@ -40,10 +41,10 @@ export default {
         trackList = `${trackList.slice(0, 1000)}...`;
       }
 
-      embed.addFields({ name: `📋 대기열 (${tracks.length}곡)`, value: trackList });
-      embed.setFooter({ text: `${displayCount}곡 표시 중 • 총 ${tracks.length}곡` });
+      embed.addFields({ name: i18n('command.queue.queueTitle', { count: tracks.length }), value: trackList });
+      embed.setFooter({ text: i18n('command.queue.footer', { shown: displayCount, total: tracks.length }) });
     } else {
-      embed.setFooter({ text: '대기열이 비어있습니다' });
+      embed.setFooter({ text: i18n('command.queue.empty') });
     }
 
     await interaction.reply({ embeds: [embed] });

--- a/src/commands/record/quaver/user.ts
+++ b/src/commands/record/quaver/user.ts
@@ -1,8 +1,8 @@
 import { type ChatInputCommandInteraction, Colors, EmbedBuilder, type SlashCommandSubcommandBuilder, TimestampStyles, time } from 'discord.js';
 import type { QuaverQPVMUser, QuaverUser } from '@/types/quaver';
 
-function getCountryName(code: string, locale: string): string {
-  if (!code) return '알 수 없음';
+function getCountryName(code: string, locale: string, fallback: string): string {
+  if (!code) return fallback;
   return new Intl.DisplayNames([locale], { type: 'region' }).of(code.toUpperCase()) || code;
 }
 
@@ -27,6 +27,7 @@ export const data = (subcommand: SlashCommandSubcommandBuilder) =>
     );
 
 export async function execute(interaction: ChatInputCommandInteraction<'cached'>) {
+  const t = interaction.i18n;
   const nickname = interaction.options.getString('nickname', true);
 
   const response = await fetch(`https://api.quavergame.com/v2/user/search/${encodeURIComponent(nickname)}`);
@@ -63,49 +64,51 @@ export async function execute(interaction: ChatInputCommandInteraction<'cached'>
     const qpvmText = await qpvmRes.text();
 
     if (!qpvmRes.ok) {
-      qpvmUnavailableMessage = 'QuaverPvM 랭크를 불러오지 못했습니다.';
+      qpvmUnavailableMessage = t('command.quaver.user.qpvmUnavailable');
     } else if (qpvmText.trim() !== 'null') {
       const rankData = JSON.parse(qpvmText) as QuaverQPVMUser;
       const winRate = rankData.matchesPlayed > 0 ? ((rankData.wins / rankData.matchesPlayed) * 100).toFixed(1) : '0.0';
-      winRateDisplay = `${winRate}% (${rankData.matchesPlayed}전 ${rankData.wins}승)`;
+      winRateDisplay = t('command.quaver.user.winRateValue', { rate: winRate, played: rankData.matchesPlayed, wins: rankData.wins });
       tierDisplay = `**${rankData.letterRank.toUpperCase()}** (#${rankData.rank})`;
       ratingDisplay = `**${rankData.rating.toFixed(2)}** ± ${rankData.sigma.toFixed(2)}`;
     }
   } catch {
-    qpvmUnavailableMessage = 'QuaverPvM 랭크를 불러오지 못했습니다.';
+    qpvmUnavailableMessage = t('command.quaver.user.qpvmUnavailable');
   }
 
   const qpvmFields = qpvmUnavailableMessage
     ? [
-        { name: '\u200B', value: '**[QuaverPvM (비공식 랭크)](https://qpvm.icedynamix.moe/)**', inline: false },
-        { name: '⚠️ 오류', value: qpvmUnavailableMessage, inline: false }
+        { name: '​', value: t('command.quaver.user.qpvmHeader'), inline: false },
+        { name: t('command.quaver.user.errorTitle'), value: qpvmUnavailableMessage, inline: false }
       ]
     : [
-        { name: '\u200B', value: '**[QuaverPvM (비공식 랭크)](https://qpvm.icedynamix.moe/)**', inline: false },
-        { name: '🏅 티어 (Tier)', value: tierDisplay, inline: true },
-        { name: '⭐ 레이팅', value: ratingDisplay, inline: true },
-        { name: '📈 승률', value: winRateDisplay, inline: true }
+        { name: '​', value: t('command.quaver.user.qpvmHeader'), inline: false },
+        { name: t('command.quaver.user.tier'), value: tierDisplay, inline: true },
+        { name: t('command.quaver.user.tierRating'), value: ratingDisplay, inline: true },
+        { name: t('command.quaver.user.winRate'), value: winRateDisplay, inline: true }
       ];
+
+  const country = getCountryName(user.country, interaction.locale, t('command.quaver.user.unknown'));
 
   const embed = new EmbedBuilder()
     .setColor(Colors.Blue)
-    .setTitle(`${user.username} 님의 정보 (4K)`)
+    .setTitle(t('command.quaver.user.title', { username: user.username }))
     .setURL(`https://quavergame.com/user/${user.id}`)
     .setThumbnail(user.avatar_url)
     .addFields(
-      { name: '🆔 유저 ID', value: user.id.toString(), inline: true },
-      { name: '🌍 글로벌 랭킹', value: `#${s4.ranks.global.toLocaleString()}`, inline: true },
-      { name: `🏁 국가 랭킹 (${getCountryName(user.country, interaction.locale)})`, value: `#${s4.ranks.country.toLocaleString()}`, inline: true },
-      { name: '📊 레이팅', value: `${s4.overall_performance_rating.toFixed(2)}`, inline: true },
-      { name: '🎯 정확도', value: `${s4.overall_accuracy.toFixed(2)}%`, inline: true },
-      { name: '🏆 랭크 점수', value: s4.ranked_score.toLocaleString(), inline: true },
-      { name: '💯 총 점수', value: s4.total_score.toLocaleString(), inline: true },
-      { name: '🕹️ 플레이 횟수', value: `${s4.play_count.toLocaleString()}회`, inline: true },
-      { name: '🔥 최대 콤보', value: `${s4.max_combo.toLocaleString()}x`, inline: true },
-      { name: '☠️ 실패 횟수', value: `${s4.fail_count.toLocaleString()}회`, inline: true },
-      { name: '📅 가입일', value: time(new Date(user.time_registered), TimestampStyles.RelativeTime), inline: true },
-      { name: '🕒 최근 활동', value: time(new Date(user.latest_activity), TimestampStyles.RelativeTime), inline: true },
-      { name: '📈 등급 분포', value: grades, inline: false },
+      { name: t('command.quaver.user.userId'), value: user.id.toString(), inline: true },
+      { name: t('command.quaver.user.globalRanking'), value: `#${s4.ranks.global.toLocaleString()}`, inline: true },
+      { name: t('command.quaver.user.countryRanking', { country }), value: `#${s4.ranks.country.toLocaleString()}`, inline: true },
+      { name: t('command.quaver.user.rating'), value: `${s4.overall_performance_rating.toFixed(2)}`, inline: true },
+      { name: t('command.quaver.user.accuracy'), value: `${s4.overall_accuracy.toFixed(2)}%`, inline: true },
+      { name: t('command.quaver.user.rankedScore'), value: s4.ranked_score.toLocaleString(), inline: true },
+      { name: t('command.quaver.user.totalScore'), value: s4.total_score.toLocaleString(), inline: true },
+      { name: t('command.quaver.user.playCount'), value: t('command.quaver.user.playCountValue', { count: s4.play_count.toLocaleString() }), inline: true },
+      { name: t('command.quaver.user.maxCombo'), value: `${s4.max_combo.toLocaleString()}x`, inline: true },
+      { name: t('command.quaver.user.failCount'), value: t('command.quaver.user.playCountValue', { count: s4.fail_count.toLocaleString() }), inline: true },
+      { name: t('command.quaver.user.registeredAt'), value: time(new Date(user.time_registered), TimestampStyles.RelativeTime), inline: true },
+      { name: t('command.quaver.user.latestActivity'), value: time(new Date(user.latest_activity), TimestampStyles.RelativeTime), inline: true },
+      { name: t('command.quaver.user.grades'), value: grades, inline: false },
       ...qpvmFields
     );
   await interaction.editReply({ embeds: [embed] });

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -26,6 +26,20 @@
 			"title": "Which country does the flag below belong to?",
 			"wrong": "{{user}} was wrong!"
 		},
+		"hangang": {
+			"avgTemp": "Average temperature",
+			"coldest": "Coldest spot",
+			"hottest": "Hottest spot",
+			"lastUpdate": "Last update",
+			"notMeasurable": "N/A",
+			"overview": "📊 At a glance",
+			"ph": "PH",
+			"stations": "Measurement stations",
+			"stationsCount": "{{count}}",
+			"temperature": "Temperature",
+			"timestamp": "Measured at",
+			"title": "🌊 Han River temperature"
+		},
 		"language": {
 			"description": "Old language: {{oldLanguage}}\nNew language: {{newLanguage}}",
 			"title": "🌐 Language has been changed."
@@ -68,11 +82,74 @@
 			"title": "🎵 Added to the playlist.",
 			"track_count": "Count"
 		},
+		"quaver": {
+			"user": {
+				"accuracy": "🎯 Accuracy",
+				"countryRanking": "🏁 Country ranking ({{country}})",
+				"errorTitle": "⚠️ Error",
+				"failCount": "☠️ Fail count",
+				"globalRanking": "🌍 Global ranking",
+				"grades": "📈 Grades",
+				"latestActivity": "🕒 Last active",
+				"maxCombo": "🔥 Max combo",
+				"playCount": "🕹️ Play count",
+				"playCountValue": "{{count}}",
+				"qpvmHeader": "**[QuaverPvM (unofficial rank)](https://qpvm.icedynamix.moe/)**",
+				"qpvmUnavailable": "Could not load QuaverPvM rank.",
+				"rankedScore": "🏆 Ranked score",
+				"rating": "📊 Rating",
+				"registeredAt": "📅 Registered",
+				"tier": "🏅 Tier",
+				"tierRating": "⭐ Rating",
+				"title": "{{username}}'s info (4K)",
+				"totalScore": "💯 Total score",
+				"unknown": "Unknown",
+				"userId": "🆔 User ID",
+				"winRate": "📈 Win rate",
+				"winRateValue": "{{rate}}% ({{played}} games, {{wins}} wins)"
+			}
+		},
 		"queue": {
+			"author": "🎤 Artist",
+			"empty": "The queue is empty",
+			"footer": "Showing {{shown}} • Total {{total}}",
+			"queueTitle": "📋 Queue ({{count}})",
+			"source": "📀 Source",
 			"title": "🎵 Queue - {{size}} songs"
 		},
 		"remove": {
 			"title": "🗑️ Removed from the queue"
+		},
+		"serverinfo": {
+			"afkChannel": "💤 AFK channel",
+			"afkTimeout": "⏰ AFK timeout",
+			"boostCount": "🌟 Boost count",
+			"boostLevel": "✨ Boost level",
+			"channelCount": "📺 Channels",
+			"countSuffix": "{{count}}",
+			"createdAt": "🎂 Created at",
+			"description": "📝 Description",
+			"id": "🆔 Server ID",
+			"locale": "🌐 Region",
+			"memberCount": "👤 Members",
+			"memberCountValue": "{{count}}",
+			"minutes": "{{count}} min",
+			"name": "📛 Name",
+			"none": "None",
+			"owner": "👑 Owner",
+			"roleCount": "🎭 Roles",
+			"rulesChannel": "🕮 Rules channel",
+			"systemChannel": "⚙️ System channel",
+			"title": "'{{name}}' info",
+			"updatesChannel": "📢 Updates channel",
+			"verification": {
+				"high": "🔴 High (10 min wait)",
+				"label": "🔒 Verification level",
+				"low": "🟡 Low (email)",
+				"medium": "🟠 Medium (5 min wait)",
+				"none": "🟢 None",
+				"veryHigh": "🟣 Very high (phone)"
+			}
 		},
 		"skip": {
 			"title": "⏩ Skipped the currently playing music!"
@@ -90,11 +167,6 @@
 			"uptime": "🕒 Uptime",
 			"user": "👥 Total user count"
 		},
-		"uptime": {
-			"startedAt": "Started at",
-			"title": "Bot Uptime",
-			"uptime": "Uptime"
-		},
 		"stealemoji": {
 			"description": "Successfully stole the emoji!",
 			"title": "🥷🏻 Steal Emoji"
@@ -109,6 +181,45 @@
 			"receive_description": "Thank you for your suggestion! We will review it as soon as possible.",
 			"receive_title": "Suggestion has been successfully sent.",
 			"title": "What do you want to suggest?"
+		},
+		"uptime": {
+			"startedAt": "Started at",
+			"title": "Bot Uptime",
+			"uptime": "Uptime"
+		},
+		"urban": {
+			"author": "Author",
+			"example": "## Example",
+			"noDefinition": "No definition",
+			"noExample": "No example",
+			"writtenOn": "Written on"
+		},
+		"userinfo": {
+			"badges": "🏅 Badges",
+			"botInfo": "🤖 Bot info",
+			"botMemory": "💾 Memory",
+			"botOs": "🖥️ OS",
+			"createdAt": "🎂 Account created",
+			"flags": {
+				"ActiveDeveloper": "🔨 Active Developer",
+				"BugHunterLevel1": "🐛 Bug Hunter Lv.1",
+				"BugHunterLevel2": "🐛 Bug Hunter Lv.2",
+				"CertifiedModerator": "🛡️ Moderator Programs Alumni",
+				"HypeSquadOnlineHouse1": "🟣 HypeSquad Bravery",
+				"HypeSquadOnlineHouse2": "🟠 HypeSquad Brilliance",
+				"HypeSquadOnlineHouse3": "🟢 HypeSquad Balance",
+				"Hypesquad": "🏠 HypeSquad Events",
+				"Partner": "🤝 Partner",
+				"PremiumEarlySupporter": "💎 Early Nitro Supporter",
+				"Staff": "👨‍💼 Discord Staff",
+				"VerifiedDeveloper": "✅ Early Verified Bot Developer"
+			},
+			"id": "🆔 ID",
+			"joinedAt": "📅 Joined server",
+			"name": "📛 Name",
+			"premiumSince": "🚀 Boosting since",
+			"roles": "🏷️ Roles ({{count}})",
+			"unknown": "Unknown"
 		}
 	},
 	"error": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -26,6 +26,20 @@
 			"title": "아래 국기는 어디 국기일까요?",
 			"wrong": "{{user}} 오답!"
 		},
+		"hangang": {
+			"avgTemp": "평균 수온",
+			"coldest": "가장 차가운 곳",
+			"hottest": "가장 따뜻한 곳",
+			"lastUpdate": "마지막 업데이트",
+			"notMeasurable": "측정 불가",
+			"overview": "📊 한눈에 보기",
+			"ph": "PH",
+			"stations": "측정 지점",
+			"stationsCount": "{{count}}곳",
+			"temperature": "수온",
+			"timestamp": "기준 시각",
+			"title": "🌊 한강 수온"
+		},
 		"language": {
 			"description": "기존 언어: {{oldLanguage}}\n변경된 언어: {{newLanguage}}",
 			"title": "🌐 언어가 변경되었습니다."
@@ -68,11 +82,74 @@
 			"title": "🎵 재생목록에 추가되었습니다.",
 			"track_count": "개수"
 		},
+		"quaver": {
+			"user": {
+				"accuracy": "🎯 정확도",
+				"countryRanking": "🏁 국가 랭킹 ({{country}})",
+				"errorTitle": "⚠️ 오류",
+				"failCount": "☠️ 실패 횟수",
+				"globalRanking": "🌍 글로벌 랭킹",
+				"grades": "📈 등급 분포",
+				"latestActivity": "🕒 최근 활동",
+				"maxCombo": "🔥 최대 콤보",
+				"playCount": "🕹️ 플레이 횟수",
+				"playCountValue": "{{count}}회",
+				"qpvmHeader": "**[QuaverPvM (비공식 랭크)](https://qpvm.icedynamix.moe/)**",
+				"qpvmUnavailable": "QuaverPvM 랭크를 불러오지 못했습니다.",
+				"rankedScore": "🏆 랭크 점수",
+				"rating": "📊 레이팅",
+				"registeredAt": "📅 가입일",
+				"tier": "🏅 티어",
+				"tierRating": "⭐ 레이팅",
+				"title": "{{username}} 님의 정보 (4K)",
+				"totalScore": "💯 총 점수",
+				"unknown": "알 수 없음",
+				"userId": "🆔 유저 ID",
+				"winRate": "📈 승률",
+				"winRateValue": "{{rate}}% ({{played}}전 {{wins}}승)"
+			}
+		},
 		"queue": {
+			"author": "🎤 아티스트",
+			"empty": "대기열이 비어있습니다",
+			"footer": "{{shown}}곡 표시 중 • 총 {{total}}곡",
+			"queueTitle": "📋 대기열 ({{count}}곡)",
+			"source": "📀 소스",
 			"title": "🎵 재생목록 - {{size}}개"
 		},
 		"remove": {
 			"title": "🗑️ 재생목록에서 제거되었습니다."
+		},
+		"serverinfo": {
+			"afkChannel": "💤 AFK 채널",
+			"afkTimeout": "⏰ AFK 시간",
+			"boostCount": "🌟 부스트 수",
+			"boostLevel": "✨ 부스트 레벨",
+			"channelCount": "📺 채널 수",
+			"countSuffix": "{{count}}개",
+			"createdAt": "🎂 서버 생성일",
+			"description": "📝 서버 설명",
+			"id": "🆔 서버 ID",
+			"locale": "🌐 서버 지역",
+			"memberCount": "👤 유저 수",
+			"memberCountValue": "{{count}}명",
+			"minutes": "{{count}}분",
+			"name": "📛 이름",
+			"none": "없음",
+			"owner": "👑 서버 소유자",
+			"roleCount": "🎭 역할 수",
+			"rulesChannel": "🕮 규칙 채널",
+			"systemChannel": "⚙️ 시스템 채널",
+			"title": "'{{name}}' 정보",
+			"updatesChannel": "📢 업데이트 채널",
+			"verification": {
+				"high": "🔴 높음 (가입 10분 대기)",
+				"label": "🔒 보안 수준",
+				"low": "🟡 낮음 (이메일 인증)",
+				"medium": "🟠 중간 (가입 5분 대기)",
+				"none": "🟢 없음",
+				"veryHigh": "🟣 매우 높음 (핸드폰 인증)"
+			}
 		},
 		"skip": {
 			"title": "⏩ 재생중인 음악을 넘겼습니다!"
@@ -90,11 +167,6 @@
 			"uptime": "🕒 가동 시간",
 			"user": "👥 전체 유저 수"
 		},
-		"uptime": {
-			"startedAt": "실행 시작",
-			"title": "봇 업타임",
-			"uptime": "가동 시간"
-		},
 		"stealemoji": {
 			"description": "이모지를 성공적으로 훔쳐왔습니다!",
 			"title": "🥷🏻 이모지 훔치기"
@@ -109,6 +181,45 @@
 			"receive_description": "답장은 DM으로 전송될 예정입니다. 빠른 시일 내에 답변드리겠습니다.",
 			"receive_title": "✉️ 성공적으로 문의가 접수되었습니다.",
 			"title": "어떤 도움이 필요하신가요?"
+		},
+		"uptime": {
+			"startedAt": "실행 시작",
+			"title": "봇 업타임",
+			"uptime": "가동 시간"
+		},
+		"urban": {
+			"author": "작성자",
+			"example": "## 예문",
+			"noDefinition": "정의 없음",
+			"noExample": "예문 없음",
+			"writtenOn": "작성일"
+		},
+		"userinfo": {
+			"badges": "🏅 배지",
+			"botInfo": "🤖 봇 정보",
+			"botMemory": "💾 메모리",
+			"botOs": "🖥️ OS",
+			"createdAt": "🎂 계정 생성일",
+			"flags": {
+				"ActiveDeveloper": "🔨 활동 중인 개발자",
+				"BugHunterLevel1": "🐛 버그 헌터 Lv.1",
+				"BugHunterLevel2": "🐛 버그 헌터 Lv.2",
+				"CertifiedModerator": "🛡️ 모더레이터 프로그램 동문",
+				"HypeSquadOnlineHouse1": "🟣 HypeSquad Bravery",
+				"HypeSquadOnlineHouse2": "🟠 HypeSquad Brilliance",
+				"HypeSquadOnlineHouse3": "🟢 HypeSquad Balance",
+				"Hypesquad": "🏠 HypeSquad 이벤트",
+				"Partner": "🤝 파트너",
+				"PremiumEarlySupporter": "💎 초기 Nitro 서포터",
+				"Staff": "👨‍💼 Discord 직원",
+				"VerifiedDeveloper": "✅ 초기 인증된 봇 개발자"
+			},
+			"id": "🆔 ID",
+			"joinedAt": "📅 서버 가입일",
+			"name": "📛 이름",
+			"premiumSince": "🚀 부스트 시작일",
+			"roles": "🏷️ 역할 ({{count}})",
+			"unknown": "알 수 없음"
 		}
 	},
 	"error": {


### PR DESCRIPTION
## Summary

하드코딩되어 있던 user-facing 한국어 텍스트를 i18n 키로 전환. ko/en_US locale 모두 채움.

| 파일 | 변경 |
|---|---|
| `serverinfo.ts` | 17개 필드 라벨 + verification level + boost level 매핑 |
| `userinfo.ts` | 12개 Discord 배지 + 필드 라벨 + 봇 정보 섹션 |
| `urban.ts` | 정의/예문 라벨, fallback 텍스트, 작성자/작성일 |
| `hangang.ts` | 제목/요약/측정값 라벨/측정 불가 |
| `queue.ts` | 아티스트/소스/대기열 헤더/footer |
| `quaver/user.ts` | 13개 필드 라벨 + QPVM 에러 메시지 + 국가명 fallback |

## 의도적 미번역
- 슬래시 명령어 이름이 한국어인 명령어 (`/시간표`, `/급식`, `/학교정보`) — NEIS 한국 학교 API 전용
- 코드 내 한국어 주석 — 개발자용

## Test plan
- [x] `bunx tsc --noEmit` 통과
- [ ] ko 사용자: 기존과 동일 출력
- [ ] en_US 사용자: 영어 라벨로 출력
- [ ] `/serverinfo`, `/userinfo`, `/urban`, `/hangang`, `/queue`, `/quaver user` 동작 확인